### PR TITLE
Fix/nollning 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,39 @@ För detta projektet krävs:
 
 ### Lokal dev miljö
 
-För att starta en lokal devmiljö där du kan redigera saker i strapi och testa sidorna i webapplikationen behöver du:
+För att starta en lokal devmiljö behöver du först klona projektet. Om [Docker Desktop](https://www.docker.com/products/docker-desktop/) används, starta denna applikation. Se till att det **inte** finns några docker images som kör på port 5050 och 5432. Kör därefter `docker compose up` i root för att starta en `nollesite` container.
 
-1. Starta CMS:et - `cd strapi` och `yarn dev`
-   - Detta kommer starta en lokal strapi instans på `http://localhost:1337`
-2. Starta Web - `cd web` och `yarn dev`
-   - Detta kommer starta en lokal webapplikation på `http://localhost:3000`
+Följande steg förklarar hur en strapi instans skapas, där du kan redigera nollningssidor. Därefter förklaras hur man skapar en lokal webapplikation för att testa nollningssidorna.
+
+#### ⚙ Strapi
+
+Skapa CMS:et på följande sätt:
+1. Skapa en `.env`-fil i `strapi/`
+   - Kopiera över innehållet från `.env.example`
+   - Fyll `.env`-filen med värden för `STRAPI_APP_KEYS`, `API_TOKEN_SALT` och `JWT_SECRET` från Bitwarden
+   - **OBS:** Använd ej `DB` variablerna från Bitwarden vid testning, då ändringar i så fall påverkar prod!
+   - > TODO: `SMTP` och `WIKI` variabler behövs ej för att få CMS:et att fungera. Men det används till ...
+2. `cd strapi`, `yarn install` och `yarn dev`
+3. En lokal strapi instans kommer startas på http://localhost:8000
+4. Skapa ett lokalt konto
+5. Ett [nollningsår kan nu skapas](https://ddgwiki.esek.se/index.php/Nollningshemsidan)!
+
+#### 🚀 Web
+
+Skapa en lokal webapplikation för nollningssidorna på följande sätt:
+1. Skapa en `.env`-fil i `web/`
+   - Kopiera över innehållet från `.env.example`
+   - Fyll i `.env`-filens `STRAPI_API_TOKEN`. Värdet för denna är en API Token som skapas i lokala Strapi instansen, på http://localhost:8000/dashboard/settings/api-tokens
+   - Lägg till `GOOGLE_API_KEY` om kalendern ska testas. Denna nyckeln finns också i Bitwarden
+2. `cd web`, `yarn install` och `yarn dev`
+3. En lokal webapplikation kommer startas på http://localhost:3000
+
+#### ❓ Felsökning
+
+Några vanliga fel som kan uppstå när en lokal dev miljö skapas, och lösningar som har upptäckts för dessa, är följande:
+- Om inte yarn-kommandon fungerar i terminalen kan [nvm](https://github.com/nvm-sh/nvm) användas för att byta version av node med `node use <version>`. Efter detta brukar yarn-kommandon fungera igen.
+- Om inte en docker container har skapats när `yarn dev` används i `strapi` kan CMS:et ladda för evigt. Se då till att stänga ner strapi instansen i terminalen med <kbd>CTRL</kbd> + <kbd>C</kbd>. Sedan kan `docker compose up` köras i root. När `yarn dev` körs igen borde CMS:et startas som tänkt.
+- Om ett nollningsår är skapat i CMS:et men inte dyker upp i webapplikationen - se till att nollningsåret har en svensk locale. Detta är egentligen en bugg, i issue https://github.com/esek/nollesite/issues/25.
 
 ## 📚 Struktur
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🥷🏻 Nollesite
+# 🧙‍♀️ Nollesite
 
-Repo för Nollningshemsidorna [`nollning.esek.se`](https://nollning.esek.se) och <s title="deprecated since 2022">[`e-nollning.nu`](https://e-nollning.nu)</s> samt alla alias `*.nollning.esek.se`.
+Repo för Nollningshemsidorna [`nollning.esek.se`](https://nollning.esek.se) och <s title="deprecated since 2022">[`e-nollning.nu`](https://e-nollning.nu)</s> samt alla alias `/\d{4}/.nollning.esek.se`.
 
 ## ⚡️ Quickstart
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Följande steg förklarar hur en strapi instans skapas, där du kan redigera nol
 #### ⚙ Strapi
 
 Skapa CMS:et på följande sätt:
-1. Skapa en `.env`-fil i `strapi/`
-   - Kopiera över innehållet från `.env.example`
-   - Fyll `.env`-filen med värden för `STRAPI_APP_KEYS`, `API_TOKEN_SALT` och `JWT_SECRET` från Bitwarden
-   - **OBS:** Använd ej `DB` variablerna från Bitwarden vid testning, då ändringar i så fall påverkar prod!
-   - > TODO: `SMTP` och `WIKI` variabler behövs ej för att få CMS:et att fungera. Men det används till ...
+1. Skapa en `.env`-fil i `strapi/` och kopiera över innehållet från `.env.example`. Inga ytterligare ändringar behöver göras för att få lokala strapi-instansen att fungera. I testing används variablerna för följande syften:
+   - `DB` - värdena för lokala postgres-instansen
+   - `STRAPI_HOST` och `STRAPI_PORT` - adressen som servern kör på
+   - `SMTP` - för att testa skicka mejl lokalt, exempelvis för att testa funktionaliteten för att ha glömt sitt lösenord
+   - <s title="deprecated">`WIKI` - används för att kunna visa en sida från DDGWikin i Strapi</s>
 2. `cd strapi`, `yarn install` och `yarn dev`
 3. En lokal strapi instans kommer startas på http://localhost:8000
 4. Skapa ett lokalt konto

--- a/strapi/yarn.lock
+++ b/strapi/yarn.lock
@@ -7821,7 +7821,7 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-plaiceholder@^2.3.0, plaiceholder@^2.5.0:
+plaiceholder@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/plaiceholder/-/plaiceholder-2.5.0.tgz#2a90c2756a597d548c8c7fae863f600de3eb0e0b"
   integrity sha512-rygdNSWuYzs1GxxGjq2FiJdJB1AUaKhUHP/M7PIrSjAAGuoJC5ACiJx+cZZ+hDmMalxsxOMw0Sbbx3LF8jemGg==
@@ -9267,13 +9267,6 @@ std-env@^3.0.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.3.2.tgz#af27343b001616015534292178327b202b9ee955"
   integrity sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==
-
-strapi-blurhash@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/strapi-blurhash/-/strapi-blurhash-1.1.1.tgz#2e782a0f5a67b75a7ca512f07bb3f99487976f7e"
-  integrity sha512-oiruVZTkl8QLv4PYpglNp7oipQwDYyvw4obUVjp/Lw7teVAtT+akONUrE1Bj4jMQEx57EojHFOYRatFEddgyIA==
-  dependencies:
-    plaiceholder "^2.5.0"
 
 strapi-plugin-local-image-sharp@^1.6.0:
   version "1.6.0"

--- a/web/README.md
+++ b/web/README.md
@@ -6,20 +6,6 @@ Skriven i [Next.js](https://nextjs.org/) för att få SSR (och för att `@afrobo
 
 Däremot används såklart [TailwindCSS](https://tailwindcss.com/) för att inte behöva skriva egen csskod (🤮).
 
-## ⚡️ Quickstart
-
-Detta är ett vanligt `Next.js`-projekt som använder sig av `yarn`, så för att starta kör du:
-
-```bash
-yarn install
-```
-
-och sedan
-
-```bash
-yarn run dev
-```
-
 ## 🎨 Design
 
 Designen är gjord av `Phøset 2022` tillsammans med [`@afroborg`](https://github.com/afroborg) och [`@blennster`](https://github.com/blennster) (och säkert andra som inte får cred). Målet var att hitta en lösning som kan fungera flera år framåt, med endast tweaking på t.ex. färger, bilder och innehåll.

--- a/web/src/components/common/components/calendar/calendar-day.tsx
+++ b/web/src/components/common/components/calendar/calendar-day.tsx
@@ -1,16 +1,15 @@
-import { CalendarEventsGroupedByDay } from '@/models/calendar';
+import { CalendarEvent, CalendarEventsGroupedByDay } from '@/models/calendar';
 import dayjs from 'dayjs';
 import React from 'react';
-import CalendarEvent from './calendar-event';
+import CalendarEventComponent from './calendar-event';
 
 const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
   date,
   events,
 }) => {
-  // Sorting events based on the start time
-  events.sort((a, b) =>
-    a.start > b.start ? 1 : -1
-  )
+  // Sorting events by their start time
+  const sortEvents = (e: CalendarEvent[]) =>
+    e.sort((a, b) => (a.start > b.start ? 1 : -1));
 
   return (
     <div className="my-4 space-y-4">
@@ -19,8 +18,8 @@ const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
       </h3>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        {events.map((e) => (
-          <CalendarEvent {...e} key={`calendar-event-${e.id}`} />
+        {sortEvents(events).map((e) => (
+          <CalendarEventComponent {...e} key={`calendar-event-${e.id}`} />
         ))}
       </div>
     </div>

--- a/web/src/components/common/components/calendar/calendar-day.tsx
+++ b/web/src/components/common/components/calendar/calendar-day.tsx
@@ -7,6 +7,11 @@ const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
   date,
   events,
 }) => {
+  // Sorting events based on the start time
+  events.sort((a, b) =>
+    a.start.toString() > b.start.toString() ? 1 : -1
+  )
+
   return (
     <div className="my-4 space-y-4">
       <h3 className="text-lg font-semibold capitalize">

--- a/web/src/components/common/components/calendar/calendar-day.tsx
+++ b/web/src/components/common/components/calendar/calendar-day.tsx
@@ -9,7 +9,7 @@ const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
 }) => {
   // Sorting events based on the start time
   events.sort((a, b) =>
-    a.start.toString() > b.start.toString() ? 1 : -1
+    a.start > b.start ? 1 : -1
   )
 
   return (

--- a/web/src/components/common/components/calendar/calendar-day.tsx
+++ b/web/src/components/common/components/calendar/calendar-day.tsx
@@ -1,7 +1,7 @@
-import { CalendarEvent, CalendarEventsGroupedByDay } from '@/models/calendar';
+import { CalendarEventsGroupedByDay } from '@/models/calendar';
 import dayjs from 'dayjs';
 import React from 'react';
-import CalendarEventComponent from './calendar-event';
+import CalendarEvent from './calendar-event';
 
 const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
   date,
@@ -15,7 +15,7 @@ const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         {events.map((e) => (
-          <CalendarEventComponent {...e} key={`calendar-event-${e.id}`} />
+          <CalendarEvent {...e} key={`calendar-event-${e.id}`} />
         ))}
       </div>
     </div>

--- a/web/src/components/common/components/calendar/calendar-day.tsx
+++ b/web/src/components/common/components/calendar/calendar-day.tsx
@@ -7,10 +7,6 @@ const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
   date,
   events,
 }) => {
-  // Sorting events by their start time
-  const sortEvents = (e: CalendarEvent[]) =>
-    e.sort((a, b) => (a.start > b.start ? 1 : -1));
-
   return (
     <div className="my-4 space-y-4">
       <h3 className="text-lg font-semibold capitalize">
@@ -18,7 +14,7 @@ const CalendarDay: React.FC<CalendarEventsGroupedByDay> = ({
       </h3>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        {sortEvents(events).map((e) => (
+        {events.map((e) => (
           <CalendarEventComponent {...e} key={`calendar-event-${e.id}`} />
         ))}
       </div>

--- a/web/src/components/layout/navbar/navbar-logo.tsx
+++ b/web/src/components/layout/navbar/navbar-logo.tsx
@@ -52,8 +52,8 @@ const NavbarLogo: React.FC<StrapiFile> = ({ url, alternativeText }) => {
 
   const imgSize = 64; // the size we want the image to be in the navbar
   const src = toAssetUrl(
-    `${url}?format=webp&height=${imgSize * 5}&width=${imgSize * 5}`
-  ); // 5x the size of the logo so that it's still clear when scaled
+    `${url}?format=webp&height=2000&width=2000`
+  ); // Setting the resolution of the logo to 2000x2000 px so that it's still clear when scaled
 
   return (
     <div className="h-16 w-16">

--- a/web/src/components/layout/navbar/navbar-logo.tsx
+++ b/web/src/components/layout/navbar/navbar-logo.tsx
@@ -52,8 +52,8 @@ const NavbarLogo: React.FC<StrapiFile> = ({ url, alternativeText }) => {
 
   const imgSize = 64; // the size we want the image to be in the navbar
   const src = toAssetUrl(
-    `${url}?format=webp&height=2000&width=2000`
-  ); // Setting the resolution of the logo to 2000x2000 px so that it's still clear when scaled
+    `${url}?format=webp&height=500&width=500`
+  ); // Setting the resolution of the logo to 500x500 px so that it's still clear when scaled
 
   return (
     <div className="h-16 w-16">

--- a/web/src/pages/api/calendar/index.ts
+++ b/web/src/pages/api/calendar/index.ts
@@ -95,7 +95,9 @@ const groupEventsByDay = (
 ): CalendarEventsGroupedByDay[] => {
   const grouped: Record<string, CalendarEvent[]> = {};
 
-  events.forEach((event) => {
+  events.sort(
+    (a, b) => (a.start > b.start ? 1 : -1)
+  ).forEach((event) => {
     const start = dayjs(event.start);
     const key = start.format('YYYY-MM-DD');
 
@@ -107,8 +109,7 @@ const groupEventsByDay = (
   });
 
   return Object.entries(grouped)
-    .map(([date, events]) => ({ date, events }))
-    .sort((a, b) => (a.date > b.date ? 1 : -1));
+    .map(([date, events]) => ({date, events}))
 };
 
 /**


### PR DESCRIPTION
Ökar upplösningen för nollningsårets logga för att denna ska synas bättre.

Löser #12 genom att sortera kalendern baserat på evenemangs starttid.

Uppdaterar READMEs för att bland annat förtydliga hur en lokal dev miljö skapas.