### PR TITLE
Make the calendar show the correnct data 

### DIFF
--- a/web/src/components/common/components/calendar/calendar.tsx
+++ b/web/src/components/common/components/calendar/calendar.tsx
@@ -32,9 +32,14 @@ const Calendar: React.FC<Content<'content.calendar'>> = ({ calendarUrl }) => {
     setIncludePast(value)
   }
 
+  // Function added to verify based on the local storage if the full calendar should be loaded or not
+  const shouldIncludePast = () => {
+    return window.localStorage.getItem("includePast") !== "false"
+  }
+
   // Triggers on page load to update the includePast variable to the value last set by the user
   useEffect(() => {
-    setIncludePast(window.localStorage.getItem("includePast") === "true")
+    setIncludePast(shouldIncludePast)
   }, []);
 
   /**
@@ -60,7 +65,7 @@ const Calendar: React.FC<Content<'content.calendar'>> = ({ calendarUrl }) => {
       setEvents(events);
     };
 
-    getCalendarInfo(includePast);
+    getCalendarInfo(shouldIncludePast());
   }, [calendarUrl, includePast]);
 
   /**


### PR DESCRIPTION
The calendar would always show the full calendar regardless of the value of the checkbox even if the checkbox is unticked. It now updates the calendar appropriately and is able to show only the upcoming events or all events.